### PR TITLE
Remove header section and revert to older version

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -76,7 +76,7 @@ async def query_documents(request: QueryRequest):
 
         print(f"Error in query_documents: {str(e)}")
         print(traceback.format_exc())
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=str(e)) from e
 
 
 @app.get("/api/courses", response_model=CourseStats)
@@ -89,7 +89,7 @@ async def get_course_stats():
             course_titles=analytics["course_titles"],
         )
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=str(e)) from e
 
 
 @app.on_event("startup")

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,11 +29,6 @@
     </button>
 
     <div class="container">
-        <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
-        </header>
-
         <div class="main-content">
             <!-- Left Sidebar -->
             <aside class="sidebar">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -69,27 +69,6 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
-header {
-    display: none;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
-
 /* Main Content Area with Sidebar */
 .main-content {
     flex: 1;
@@ -750,15 +729,7 @@ details[open] .suggested-header::before {
     .chat-main {
         order: 1;
     }
-    
-    header {
-        padding: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
-    }
-    
+
     .chat-messages {
         padding: 1rem;
     }


### PR DESCRIPTION
Fixes #3

## Changes
- Removed "Course Materials Assistant" h1 header
- Removed subtitle about asking questions
- Removed entire header element from HTML
- Cleaned up related CSS styles
- Preserved theme toggle button functionality

Generated with [Claude Code](https://claude.ai/code)